### PR TITLE
Fix link to submission page in docs

### DIFF
--- a/docs/02-for-app-authors/06-maintenance.md
+++ b/docs/02-for-app-authors/06-maintenance.md
@@ -1,6 +1,6 @@
 # Maintenance
 
-This is a guide in how to maintain your application once it is on Flathub. It assumes your application is already on Flathub, and that you have access rights to its repository. If this is not true, please read the [submission](submission) page first and check your email for GitHub repository access requests.
+This is a guide in how to maintain your application once it is on Flathub. It assumes your application is already on Flathub, and that you have access rights to its repository. If this is not true, please read the [submission](/docs/for-app-authors/submission) page first and check your email for GitHub repository access requests.
 
 ## The repository
 


### PR DESCRIPTION
This PR fixes the invalid link to [submission page](https://docs.flathub.org/docs/for-app-authors/submission/) in docs to correctly point to the new page path.

The fix follows the format of other links in the docs which work correctly, such as the requirements link in the first paragraph of [`Before submission`](https://github.com/flathub-infra/documentation/blob/main/docs/02-for-app-authors/05-submission.md#before-submission) in submission page. 

The PR needs testing. I did not set up the development environment to test the change.