### PR TITLE
add link to KDE VDG room

### DIFF
--- a/blog/2024-01-08/index.md
+++ b/blog/2024-01-08/index.md
@@ -37,7 +37,7 @@ We're also introducing a new review system for app metadata, where editors rate 
 
 If editors flagged issues with your app you can address them in the next release. Once the new release is on Flathub you can request a re-review. The status of your app will be updated accordingly.
 
-If you are not an icon designer, getting your icon to meet the guidelines can be challenging. Luckily there are designers from the community you can ask for help! The [GNOME App Icon Design Matrix room](https://matrix.to/#/#appicondesign:gnome.org) is a good place to ask.
+If you are not an icon designer, getting your icon to meet the guidelines can be challenging. Luckily there are designers from the community you can ask for help! The [GNOME App Icon Design](https://matrix.to/#/#appicondesign:gnome.org) and [KDE Visual Design Group](https://matrix.to/#/#visualdesigngroup:kde.org) Matrix rooms are good examples of places to ask.
 
 This does not affect the app review process for apps being published on Flathub. We will continue to accept apps that don't fully meet the new quality guidelines. However, we do want to highlight apps that meet the guidelines, and try to show them in more prominent places on the website.
 


### PR DESCRIPTION
There has been raised concerns about the post linking solely to a GNOME-centric room as a source of app icon design help. While this has turned out to be due to the room being the only known practical resource at the time of writing the article, it would be good to bring other platforms more visibly into it to make it 100% clear that this is an initiative for all communities with apps on Flathub, and not just GNOME. The KDE VDG room is a catchall for KDE design stuff, so let's give KDE app developers somewhere to go too. I have asked the KDE folks, and they are ok with this.