### PR TITLE
Quality guidelines: clarify app name section

### DIFF
--- a/docs/02-for-app-authors/03-appdata-guidelines/01-quality-guidelines.md
+++ b/docs/02-for-app-authors/03-appdata-guidelines/01-quality-guidelines.md
@@ -84,7 +84,7 @@ The name should be just the name, without any additional info. For example, don'
 - Apostrophe (Special Edition)
   :::
 
-If the app is a distinct edition among different versions of your app on Flathub (e.g. `Plex` for desktop versus `Plex HTPC` for the home theater version), then using the full name including the edition may be acceptable.
+If the app is distinct among different versions of your app on Flathub (e.g. `Firefox Beta` versus the standard `Firefox`), then using the full name including the edition may be acceptable.
 
 ### No weird formatting
 

--- a/docs/02-for-app-authors/03-appdata-guidelines/01-quality-guidelines.md
+++ b/docs/02-for-app-authors/03-appdata-guidelines/01-quality-guidelines.md
@@ -75,28 +75,39 @@ The name should ideally be no longer than 15 characters, and must be shorter tha
 
 ### Just the name
 
-The name should be just the name, without any additional info. For example, don't append what the app does to the name; use the summary to provide this information instead.
+The name should be just the short name, without any additional information. For example, don't append what the app does or is used for to the name; use the summary to provide this information instead.
 
 :::danger Bad examples
 
-- Apostrophe - Markdown Editor
-- Apostrophe (Markdown Editor)
-- Apostrophe (Special Edition)
+- Krita - Digital Painting, Creative Freedom
+- Fractal (Matrix Client)
+- Apostrophe: the best free Markdown editor
+- Firefox Web Browser
+  :::
+  
+  :::tip Good examples
+
+- Krita
+- Fractal
+- Apostrophe
+- Firefox
   :::
 
 If the app is distinct among different versions of your app on Flathub (e.g. `Firefox Beta` versus the standard `Firefox`), then using the full name including the edition may be acceptable.
 
 ### No weird formatting
 
-The name should not have any weird formatting or punctuation. For example, it should not be all-lowercase, all-uppercase, camel case, pascal case, or contain dashes or periods. Cases where the formatting is part of an established brand may be exempt (e.g. `VLC`).
+App names should avoid nonstandard formatting and punctuation. For example, avoid all-lowercase, all-uppercase, camel/pascal case, and punctuation like dashes or periods.
 
 :::danger Bad examples
 
-- apostrophe
-- APOSTROPHE
+- krita
+- FRACTAL
 - ApostropheEditor
-- Apostrophe.org
+- Firefox.org
   :::
+
+Cases where the formatting is part of an established brand may be exempt (e.g. `VLC`).
 
 ## Summary
 

--- a/docs/02-for-app-authors/03-appdata-guidelines/01-quality-guidelines.md
+++ b/docs/02-for-app-authors/03-appdata-guidelines/01-quality-guidelines.md
@@ -75,7 +75,7 @@ The name should ideally be no longer than 15 characters, and must be shorter tha
 
 ### Just the name
 
-The name should be just the name, without any additional info. For example, don't append what the app does to the name, and use the summary to provide this extra information instead.
+The name should be just the name, without any additional info. For example, don't append what the app does to the name; use the summary to provide this information instead.
 
 :::danger Bad examples
 
@@ -84,9 +84,11 @@ The name should be just the name, without any additional info. For example, don'
 - Apostrophe (Special Edition)
   :::
 
+If the app is a distinct edition among different versions of your app on Flathub (e.g. `Plex` for desktop versus `Plex HTPC` for the home theater version), then using the full name including the edition may be acceptable.
+
 ### No weird formatting
 
-The name should not have any weird formatting or punctuation. For example, it should not be all-lowercase, all-uppercase, camel case, or contain dashes or periods. Cases where the weird formatting is part of the brand are exempt from this (e.g. `VLC`).
+The name should not have any weird formatting or punctuation. For example, it should not be all-lowercase, all-uppercase, camel case, pascal case, or contain dashes or periods. Cases where the formatting is part of an established brand may be exempt (e.g. `VLC`).
 
 :::danger Bad examples
 


### PR DESCRIPTION
Keeps the same intent, but:

- Adds an example to clarify when an app name can include an edition (e.g. `Discord Canary` or `Plex HTPC`) based on feedback

   _I don't actually love the `Plex HTPC` example, but that's what Plex uses as their name for the distinct home theater version of the app (which is designed to be driven with a remote on a TV, not a mouse and keyboard on a desktop). I'm open to another example; the ones mentioned to me were `Discord Canary` but it's not public-facing, and `Firefox ESR` but that's not on Flathub, so… 🤷🏻_

- Minor cleanups for concision

- Clarify where formatting is part of _an established_ brand; someone pointed out the app name is the brand so this exemption makes no sense unless we qualify it a bit