### PR TITLE
Fix link to shared modules

### DIFF
--- a/docs/02-for-app-authors/02-requirements.md
+++ b/docs/02-for-app-authors/02-requirements.md
@@ -31,7 +31,7 @@ The manifest must be at the top level and named after the application ID with th
 
 Every repository must contain a manifest describing how to build the application. If the application, and hence repository, is called `com.example.MyCoolApp`, this file must be called `com.example.MyCoolApp.json` or `com.example.MyCoolApp.yaml`. This is the only required file!
 
-This manifest may import other manifest files in the same repository. It's quite common to add the [shared-modules](shared-modules) repository as a submodule.
+This manifest may import other manifest files in the same repository. It's quite common to add the [shared-modules](../shared-modules) repository as a submodule.
 
 #### Example manifest
 

--- a/docs/02-for-app-authors/02-requirements.md
+++ b/docs/02-for-app-authors/02-requirements.md
@@ -31,7 +31,7 @@ The manifest must be at the top level and named after the application ID with th
 
 Every repository must contain a manifest describing how to build the application. If the application, and hence repository, is called `com.example.MyCoolApp`, this file must be called `com.example.MyCoolApp.json` or `com.example.MyCoolApp.yaml`. This is the only required file!
 
-This manifest may import other manifest files in the same repository. It's quite common to add the [shared-modules](../shared-modules) repository as a submodule.
+This manifest may import other manifest files in the same repository. It's quite common to add the [shared-modules](./shared-modules) repository as a submodule.
 
 #### Example manifest
 


### PR DESCRIPTION
Current link goes to https://docs.flathub.org/docs/for-app-authors/requirements/shared-modules while the right one is https://docs.flathub.org/docs/for-app-authors/shared-modules