### PR TITLE
Metadata Guidelines post: summarize and truncate for index

### DIFF
--- a/blog/2024-01-08/index.md
+++ b/blog/2024-01-08/index.md
@@ -9,8 +9,6 @@ Flathub has grown massively over the past few years, making it easier than ever 
 
 <!-- truncate -->
 
-## Growth
-
 Today, Flathub has over 2,400 apps, including many of the big names you would expect. In the early days our goal was mostly to make it easy to get the latest version of popular apps via Flatpak, and we can safely say this has been achieved: not only can you get pretty much any app on Flathub, they are often directly maintained by the developer—and it's the primary channel many new app developers choose for shipping their apps.
 
 ![App cards with high quality metadata on the homepage](good-metadata-apps.png)

--- a/blog/2024-01-08/index.md
+++ b/blog/2024-01-08/index.md
@@ -5,13 +5,18 @@ authors: [razze, bertob]
 tags: [flathub, quality]
 ---
 
-Flathub has grown massively over the past few years, with over 2400 apps at present. In the early days our goal was mostly to make it easy to get the latest version of popular apps via Flatpak. Today we can safely say that this goal has been achieved!
+Flathub has grown massively over the past few years, making it easier than ever to get a ton of apps all from one place—but with that growth comes new problems. We're here with a solution to ensure developers' apps, Flathub, and the entire Linux desktop ecosystem is presented in what we believe is the best light possible.
 
-Not only can you get pretty much any app on Flathub, they are often directly maintained by the developer, and it's the primary channel many new app developers choose for shipping their apps.
+<!-- truncate -->
+
+## Growth
+
+Today, Flathub has over 2,400 apps, including many of the big names you would expect. In the early days our goal was mostly to make it easy to get the latest version of popular apps via Flatpak, and we can safely say this has been achieved: not only can you get pretty much any app on Flathub, they are often directly maintained by the developer—and it's the primary channel many new app developers choose for shipping their apps.
 
 ![App cards with high quality metadata on the homepage](good-metadata-apps.png)
 
 ## More Apps, More Problems
+
 However, having lots of apps comes with some new (in this case nice to have) problems. While there are a lot of beautiful modern apps, there are also a lot of apps with low quality metadata, ugly icons, or out of date screenshots. This means that looking at the new and updated lists on the Flathub home page you get the impression that most of the apps on Flathub are low quality.
 
 One of the biggest reasons for the prevalence of low quality app metadata is probably that historically people were not discovering new apps from their repositories very often. Instead, they were mostly installing the same few classics with well-known brands (VLC, Blender, etc.), or relying on word of mouth for discovery. Now that new apps are being released on a weekly basis, app metadata becomes much more important for introducing people to these new apps.
@@ -20,9 +25,10 @@ The unfortunate result of the status quo in metadata quality is that many apps d
 
 So how can we make Flathub a place for people to discover awesome apps? We've thought about this quite a bit, and landed on a two-pronged approach:
 1. Raise the bar for metadata for all apps
-2. Introduce curation to hightlight the best apps
+2. Introduce curation to highlight the best apps
 
 ## Raising the Bar
+
 As a first step towards improving metadata quality across the board we have added new, detailed [documentation for app metadata](https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/quality-guidelines). This new page goes over all the most important aspects, and which common mistakes to avoid. These include, for example:
 
 - App icons that fill the entire canvas
@@ -42,6 +48,7 @@ If you are not an icon designer, getting your icon to meet the guidelines can be
 This does not affect the app review process for apps being published on Flathub. We will continue to accept apps that don't fully meet the new quality guidelines. However, we do want to highlight apps that meet the guidelines, and try to show them in more prominent places on the website.
 
 ## Curation
+
 Our hope is that with better documentation and developer outreach we can get to a solid set of apps with high quality metadata: Short descriptions, good icons, correctly sized screenshots with good content, and so on. Once we have that, we have a lot of new possibilities with regard to curation. For example, we've been exploring having app banners with app icons and screenshots on the home page. Other ideas we'd like to experiment with in the future include curated lists of apps, seasonal/topical recommendations, and editorial blog posts.
 
 ![Flathub home page mockup with app banners including screenshots](homepage-banners.png)
@@ -55,6 +62,7 @@ This effort will also help to improve the Flathub-wide search and the discoverab
 ![Mockup of GNOME Software with banners including screenshots](banner-native.png)
 
 ## What's Next?
+
 As of today, if you have an app on Flathub you can log in on the website, and see the app metadata ratings for your apps. Please have a look at your apps' ratings and the new documentation and make sure your app's metadata is in shape when we start rolling out banners over the coming weeks :)
 
 If you run into issues or have questions please contact us in [#flathub on Matrix](https://matrix.to/#/#flathub:matrix.org).


### PR DESCRIPTION
Cherry-picked as requested from #188

Adds a summary and truncate tag to the top of the Metadata Guidelines post so it doesn't spit the whole post out on the index (important as we start writing more posts).

In general, we should format posts this way with a one-paragraph intro at the top that acts as a summary to get people to click through to read.

I also fixed one typo (`highlight`) and added whitespace beneath headings for authoring legibility (doesn't affect the presentation).