### PR TITLE
Blog: set explicitly-relative path for image

### DIFF
--- a/blog/2024-01-25/index.md
+++ b/blog/2024-01-25/index.md
@@ -3,7 +3,7 @@ slug: over-one-million-active-users-and-growing
 title: Over One Million Active Users, and Growing
 authors: [cassidyjames]
 tags: [flathub, milestone, stats]
-image: ./images/milestones.png
+image: ./milestones.png
 ---
 
 Earlier this month we shared [new app metadata guidelines](../2024-01-08/index.md) in response to the growth and maturity of Flathub. Today we're proud to share about that growth in a bit more detail including a huge milestone, how we calculate stats, and what we believe is driving that growth.

--- a/blog/2024-01-25/index.md
+++ b/blog/2024-01-25/index.md
@@ -3,7 +3,7 @@ slug: over-one-million-active-users-and-growing
 title: Over One Million Active Users, and Growing
 authors: [cassidyjames]
 tags: [flathub, milestone, stats]
-image: milestones.png
+image: ./images/milestones.png
 ---
 
 Earlier this month we shared [new app metadata guidelines](../2024-01-08/index.md) in response to the growth and maturity of Flathub. Today we're proud to share about that growth in a bit more detail including a huge milestone, how we calculate stats, and what we believe is driving that growth.


### PR DESCRIPTION
Annoyingly, the path actually being used on the live site is relative to the base URL, not the post URL: `https://docs.flathub.org/milestones.png`

Maybe it needs to be explicitly relative (e.g. `./milestones.png`, if I'm reading [this issue](https://github.com/facebook/docusaurus/issues/6718) correctly? Otherwise I guess we'd either need to put the `milestones.png` image somewhere in `static/img/` or include the full URL (with hash) here.