### PR TITLE
Refactor appdata guidelines to provide more examples

### DIFF
--- a/docs/02-for-app-authors/02-requirements.md
+++ b/docs/02-for-app-authors/02-requirements.md
@@ -199,9 +199,9 @@ Do note that CLI applications do not require a `.desktop` file but TUI applicati
 
 ### Appstream
 
-Appstream is the standard used to provide metadata about applications. Applications must provide appstream data and pass [validation](/docs/for-app-authors/appdata-guidelines/#use-flathubs-appstream-util). If application metadata has not been provided by the upstream, it should be licensed with [Creative Commons Zero, version 1](https://creativecommons.org/choose/zero/), by stating `CC0-1.0` in `metadata_license`.
+Appstream is the standard used to provide metadata about applications. Applications must provide appstream data and pass [validation](/docs/for-app-authors/appdata-guidelines/#use-flathubs-appstream-util).
 
-In [AppData guidelines](/docs/for-app-authors/appdata-guidelines) you'll find tips/best practices to help you get your AppData up to spec. For information about appstream, see [its documentation](https://www.freedesktop.org/software/appstream/docs/index.html).
+Please read the [AppData guidelines](/docs/for-app-authors/appdata-guidelines) for more information.
 
 ### .desktop files
 

--- a/docs/02-for-app-authors/03-appdata-guidelines/index.md
+++ b/docs/02-for-app-authors/03-appdata-guidelines/index.md
@@ -1,14 +1,16 @@
 # AppData guidelines
 
-These aren’t necessarily _requirements_, those are covered in [requirements](/docs/for-app-authors/requirements#appstream). These are more tips/best practices to help you get your AppData up to spec.
+These are a set of guidelines for AppData that should be followed for submission on Flathub.
 
 :::note
-These guidelines are curated for Flathub use-cases, they don’t cover anything else. Don’t forget to consult the [official appstream documentation](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html) for more in-depth info.
+Please consult the [official appstream documentation](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html) for more in-depth info.
 :::
 
-## Use Flathub's `appstream-util`
+## Validation
 
-Flathub uses modified `appstream-util` to validate AppData during build. To run the same check locally, you can install and run it with a simple:
+All appdata must pass validation by `appstream-util`. Flathub uses modified `appstream-util` to validate AppData during build.
+
+To run the same check locally, you can install and run it with a simple:
 
 ```bash
 flatpak install -y flathub org.flatpak.Builder
@@ -19,8 +21,6 @@ flatpak run --command=appstream-util org.flatpak.Builder validate tld.domain.app
 
 Place the AppData file into `/app/share/metainfo/`, name it `%{id}.metainfo.xml`, where `%{id}` is the [ID](#id).
 
-The old path is `/app/share/appdata/`—you needn’t fix this, it’ll work, but bonus points if you do.
-
 ## Upgrading
 
 If you already have an AppData file, it’s a good idea to run it through `appstream-util upgrade`, which does some automatic fixes.
@@ -29,7 +29,7 @@ Although for backwards compatibility with RHEL 7 it uses `<component type="deskt
 
 ## Header
 
-All AppData files should start with:
+All AppData files must start with:
 
 ```xml title="tld.domain.appid.metainfo.xml"
 <?xml version="1.0" encoding="UTF-8"?>
@@ -37,13 +37,14 @@ All AppData files should start with:
 <component type="desktop-application">
 ```
 
-:::note
-The copyright notice is only necessary to pass `validate-strict`, but it’s still a good idea.
-:::
+`type="desktop-application"` is for graphical desktop applications.
+Console applications must use `type="console-application"` and extensions
+must use `type="addon"`. SDK extensions or runtimes can use
+`type="runtime"`.
 
 ## ID
 
-The ID should be the same as the [Application-ID](./../requirements#application-id):
+The ID must be same as the [Application-ID](./../requirements#application-id):
 
 ```xml
 <!-- Good -->
@@ -57,19 +58,210 @@ The ID should be the same as the [Application-ID](./../requirements#application-
 <id>qtdemo</id>
 ```
 
-:::note
-When omitting the `.desktop` part, you have to add a `type="desktop-id"` [launchable](#launchable) in order for data to be pulled from the desktop file.
-:::
+## License
+
+All appdata must have a [metadata license tag](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-metadata_license)
+that is the license of the appdata file itself.
+
+If application metadata has not been provided by the upstream, it should be licensed with [Creative Commons Zero, version 1](https://creativecommons.org/choose/zero/).
+
+```xml
+<metadata_license>CC0-1.0</metadata_license>
+```
+
+Followed by the project license:
+
+```xml
+<project_license>GPL-3.0</project_license>
+```
+
+The value must be a valid [SPDX license identifier](https://spdx.org/licenses/).
+
+Proprietary applications/custom licenses can use
+`LicenseRef-proprietary` with a link to the license:
+
+```xml
+<project_license>LicenseRef-proprietary=https://example.org/legal/</project_license>
+```
+
+## Name, summary and developer name
+
+```xml
+<name>App Name</name>
+<summary>Short summary</summary>
+```
+Please make sure to follow the [quality guidelines](/docs/for-app-authors/appdata-guidelines/quality-guidelines#app-name)
+for `name` and `summary`.
+
+A `developer_name` tag must be present. Flathub currently does not support
+the newer `developer` tag.
+
+```xml
+<developer_name>Developer name</developer_name>
+```
+
+## Description
+
+A short and informative description must be present. Please follow the
+[specification](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-description)
+for the formatting options allowed. All HTML tags are not supported.
+
+The number of paragraphs must not exceed 15. In general it should look
+something like this:
+
+```xml
+<description>
+  <p>Some description</p>
+  <p>Some description</p>
+  <p>A list of features</p>
+  <ul>
+    <li>Feature 1</li>
+    <li>Feature 2</li>
+    <li>Feature 3</li>
+  </ul>
+</description>
+```
 
 ## Launchable
 
-Basically describes how to launch this software. If a desktop file is linked, `appstream-builder` will pull data from it, namely categories and icons.
+All graphical applications having a desktop file must have this tag in
+the appdata. If this is present, `appstream-compose` will pull
+icons, keywords and categories from the desktop file.
+
+The value must be the [Application-ID](./../requirements#application-id)
+followed by `.desktop` suffix.
 
 ```xml
 <launchable type="desktop-id">org.flatpak.qtdemo.desktop</launchable>
 ```
 
-The value of `launchable` is the name of the desktop file for the application. If you use `rename-desktop-file` in the manifest, it will also take care of changing it in the appstream file.
+If `rename-desktop-file` is used in the manifest, this tag will also
+be renamed.
+
+Console applications having no desktop file can use the `provides` tag
+described below.
+
+## Provides
+
+This can be used to link to other instances of the application using a
+different ID. For example if the the app was renamed at one point or there
+are distributions using the old naming scheme out there. It also prevents
+ODRS reviews to be “lost” on a rename.
+
+:::note
+
+The old desktop file name is automatically added if we use `rename-desktop-file` in the Flatpak manifest.
+
+:::
+
+```xml
+<provides>
+  <id>qtdemo.desktop</id>
+</provides>
+```
+
+Console applications must add their main binary name to the provides tag:
+
+```xml
+<provides>
+  <binary>foo</binary>
+</provides>
+```
+
+Please see the [specification](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-provides)
+to know more.
+
+## Categories and keywords
+
+If there’s a `type="desktop-id"` [launchable](#launchable), they are
+pulled from the desktop file and merged in the appdata. So defining them
+seperately in the appdata is not necessary.
+
+Please see the [specification](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-categories)
+on how to define them in appdata.
+
+If they are present in both places, appstream will merge them.
+
+Please don't use, generic categories like
+`KDE, GTK, Qt, Application, GNOME, GUI`. These can be placed in `keywords`.
+
+## OARS information
+
+Use the [OARS website](https://hughsie.github.io/oars/generate.html) to
+generate these and make sure to use `type="oars-1.1"`.
+
+Applications must be properly tagged by OARS data based on their content.
+
+```xml
+<content_rating type="oars-1.1" />
+```
+
+## URL
+
+At minimum `url type="homepage"` tag must be present to pass validation
+but it is best to include other links too.
+
+```xml
+<url type="bugtracker">https://example.org/issues</url>
+<url type="homepage">https://example.org/</url>
+<url type="donation">https://example.org/donate</url>
+<url type="contact">https://example.org/contact</url>
+<url type="faq">https://example.org/faq</url>
+```
+
+## Screenshots
+
+All graphical applications must have one or more screenshots in the
+appdata. Please make sure to follow the [quality guidelines](/docs/for-app-authors/appdata-guidelines/quality-guidelines#screenshots)
+for screenshots.
+
+The link inside `image` tag must be a direct link to a image resource on
+the web. If the images are hosted in a git repository, the
+link should be from a tag or a commit and not a branch.
+
+It should look something like this:
+
+```xml
+<screenshots>
+  <screenshot type="default">
+    <image>https://example.org/example1.png</image>
+    <caption>A caption</caption>
+  </screenshot>
+  <screenshot>
+    <image>https://example.org/example2.png</image>
+    <caption>A caption</caption>
+  </screenshot>
+</screenshots>
+```
+
+## Release
+
+Applications must supply a releases tag in their appdata to pass
+validation. Please make sure to also follow the [quality guidelines](/docs/for-app-authors/appdata-guidelines/quality-guidelines#release-notes)
+while writing release notes. Releases in appdata should look like this:
+
+```xml
+<releases>
+  <release version="X.Y.Z" date="YYYY-MM-DD">
+    <description>
+      <p>Release description</p>
+        <ul>
+          <li>List of changes</li>
+          <li>List of changes</li>
+        </ul>
+    </description>
+  </release>
+  <release version="X.Y.Z" date="YYYY-MM-DD">
+    <description>
+      <p>Release description</p>
+        <ul>
+          <li>List of changes</li>
+          <li>List of changes</li>
+        </ul>
+    </description>
+  </release>
+</releases>
+```
 
 ## Translations
 
@@ -91,52 +283,17 @@ If it’s somewhere different (Qt apps often name the directory “locale” and
 
 To see if it was detected correctly, check the [generated output](#checking-the-generated-output).
 
-## Provides
-
-We can use this to link to other instances using a different ID, whether the app was renamed, but especially if there are distributions using the old naming scheme out there. It also prevents ODRS reviews to be “lost” on a rename.
-
-:::note
-
-The old desktop file name is automatically added if we use `rename-desktop-file` in the Flatpak manifest.
-
-:::
-
-```xml
-<provides>
-  <id>qtdemo.desktop</id>
-</provides>
-```
-
-## Icons and categories
-
-If there’s a `type="desktop-id"` [launchable](#launchable), they get pulled from it. Most of the icon not found errors with the flathub builder can be traced down to the `launchable` value not matching the desktop file name.
-
-Don’t set them in the AppData unless you want to override them (even though then it might be a better idea to patch the desktop file itself).
-
-## OARS information
-
-Use the [OARS website](https://hughsie.github.io/oars/generate.html) to generate these. The old generator also included all the `none`-value entries—it no longer does this, you can safely remove them. If it only consists of `none` values, it’s safe to shorten it to just:
-
-```xml
-<content_rating type="oars-1.1" />
-```
-
-## Content
-
-For the quick guidelines for the actual content (descriptions, screenshots), see the Appstream [docs](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html).
-
-## License
-
-All appdata must contain a valid SPDX license. However there isn't an [SPDX license](https://spdx.org/licenses/) for proprietary software. By convention you should use `LicenseRef-proprietary` in this case.
-
 ## Manifest location
 
-If you are using the flathub infrastructure (you have a repo on flathubs github) you don't have to do anything. If you are using your own infrastructure and have the manifest in your repo you should add this to your appdata, poiting to whereever your manifest is located:
+Applications that are directly uploaded to Flathub through their own
+infrastructure and does not have a Github repo on the [Flathub
+organisation](https://github.com/flathub) must add the location to their
+flatpak manifest like so:
 
 ```xml
  <custom>
     <value key="flathub::manifest">https://example.com/url_with_a_git_hash/com.example.my-app.json</value>
-  </custom>
+ </custom>
 ```
 
 ## Checking the generated output


### PR DESCRIPTION
And also serve as a template for all the tags necessary to pass validation and Flathub guidelines.


The spec is way too verbose and provides too many options, so people get easily lost. This can be easily used as a template and also while reviewing for linking purposes.


I removed a bunch of legacy stuff like notes about `.desktop` appids etc. which is not allowed anymore in the linter https://docs.flathub.org/docs/for-app-authors/linter#appid-ends-with-lowercase-desktop, replaced "should" with "must" wherever necessary and remove some notes.