### PR TITLE
Document no-exportable-icon-installed error from linter

### DIFF
--- a/docs/02-for-app-authors/12-linter.md
+++ b/docs/02-for-app-authors/12-linter.md
@@ -652,6 +652,15 @@ using buildsystem `autotools` sets `--enable-debug=no`.
 
 This is not allowed.
 
+### no-exportable-icon-installed
+
+**Exceptions allowed**: No
+
+This means that no exportable icons were found in the [proper location](https://docs.flatpak.org/en/latest/conventions.html#appdata-files).
+An icon is considered by Flatpak to be exportable if it matches any of
+the following patterns: `$FLATPAK_ID, $FLATPAK_ID-foo, $FLATPAK_ID.foo`.
+They may end with extension suffixes like `.png` or `.svg`.
+
 ### toplevel-cleanup-debug
 
 **Exceptions allowed**: No


### PR DESCRIPTION
https://github.com/flathub-infra/flatpak-builder-lint/commit/5159397908144200fef93c2910cb0be71cdd11f4