### PR TITLE
Add a section about extension metainfo file

### DIFF
--- a/docs/02-for-app-authors/03-appdata-guidelines/index.md
+++ b/docs/02-for-app-authors/03-appdata-guidelines/index.md
@@ -358,6 +358,13 @@ flatpak manifest like so:
  </custom>
 ```
 
+## Extensions
+
+Extensions need to follow only some of the guidelines outlined above. All extensions should include a MetaInfo file
+and all application extensions must use the `extends` tag.
+
+An example of a MetaInfo file for extension is provided in the [Flatpak documentation](https://docs.flatpak.org/en/latest/extension.html#extension-manifest).
+
 ## Checking the generated output
 
 Once an app has been built, you can look for the `/app/share/app-info/xmls/<app-id>.xml.gz` archive, inside which is an XML file with all the info about the app combined into one file.


### PR DESCRIPTION
Closes https://github.com/flathub-infra/documentation/issues/22

- branching is covered in maintenance docs
- flathub.json is now obsolete since I removed those from the linter

So only the note about appdata is necessary.

Everything else is not specific to Flathub and/or is already covered.