### PR TITLE
quality-guidelines: Link Flathub's metainfo guidelines quickstart page

### DIFF
--- a/docs/02-for-app-authors/03-metainfo-guidelines/01-quality-guidelines.md
+++ b/docs/02-for-app-authors/03-metainfo-guidelines/01-quality-guidelines.md
@@ -8,7 +8,7 @@ Apps following the quality guidelines may be featured more prominently across Fl
 
 The term `must` in these guidelines is used in the context of considering whether an app passes the app listing quality checks. Apps that do not follow these guidelines may still be published on Flathub.
 
-For the basics on how to write metadata for your app, see the [Appstream Metadata Quickstart](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html).
+For the basics on how to write metadata for your app, see the [MetaInfo Guidelines](/docs/for-app-authors/metainfo-guidelines).
 
 ## General
 


### PR DESCRIPTION
Everything in https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html is covered in the Metainfo guidelines page along with the places where Flathub diverges.

The whole part about screenshots is documented in the quality guidelines page.