### PR TITLE
metainfo: Add note about developer_name tag

### DIFF
--- a/docs/02-for-app-authors/03-metainfo-guidelines/index.md
+++ b/docs/02-for-app-authors/03-metainfo-guidelines/index.md
@@ -136,7 +136,7 @@ Please make sure to follow the [quality guidelines](/docs/for-app-authors/metain
 for `name` and `summary`.
 
 :::note
-The deprecated `developer_name` tag is also supported for backwards compatibility
+The deprecated `developer_name` tag is also supported for backwards compatibility. However, it's advisable to retain it to ensure compatibility with older releases / distributions.
 :::
 
 A `developer` [tag](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer)


### PR DESCRIPTION
Add a note about deprecated `developer_name` to inform developers to removing this tag may result developer_name not be shown.

Fixes: #286