### PR TITLE
maintenance: Add a note to not EOL extensions or baseapps

### DIFF
--- a/docs/02-for-app-authors/06-maintenance.md
+++ b/docs/02-for-app-authors/06-maintenance.md
@@ -48,6 +48,10 @@ If you build for both `x86_64` and `aarch64` you do not need a `flathub.json` fi
 
 ### End of life
 
+:::note
+Extensions or BaseApps do not need to be EOL or EOL Rebased.
+:::
+
 There may come a point where an application is no longer maintained. In order to inform users at update or install time that it will no longer get updates, create `flathub.json` with these contents:
 
 ```json title="flathub.json"


### PR DESCRIPTION
If the extension point is defined in runtime and it is set to auto install on certain conditions a EOL message will appear on whenever said runtime is installed and pulls in the extension as a dependency ie. on every app install