### PR TITLE
Update 05-submission.md to add missing command

### DIFF
--- a/docs/02-for-app-authors/05-submission.md
+++ b/docs/02-for-app-authors/05-submission.md
@@ -21,7 +21,7 @@ flatpak install -y flathub org.flatpak.Builder
 
 ### Build and install
 
-Add the Flatpak repo user-wide:
+Add the Flathub repo user-wide:
 
    ```bash
    flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo

--- a/docs/02-for-app-authors/05-submission.md
+++ b/docs/02-for-app-authors/05-submission.md
@@ -21,6 +21,14 @@ flatpak install -y flathub org.flatpak.Builder
 
 ### Build and install
 
+Add the Flatpak repo user-wide:
+
+   ```bash
+   flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+   ```
+
+Then build your manifest:
+
    ```bash
    flatpak run org.flatpak.Builder --force-clean --sandbox --user --install --install-deps-from=flathub --ccache --mirror-screenshots-url=https://dl.flathub.org/media/ --repo=repo builddir <manifest>
    ```


### PR DESCRIPTION
This fixes a problem with the instructions.

If you follow them as stated (as I did), when you go to build the manifest, you will get an error:

    error: No remote refs found for ‘flathub’
    Error installing deps: running `flatpak --user install -y --noninteractive flathub org.kde.Sdk/x86_64/5.15-23.08`: Child process exited with code 1

The repo already was added system wide, and adding it again did not change the error.

Adding the repo with the --user flag allowed the build command to continue.