### PR TITLE
quality guidelines: Mention accent colors

### DIFF
--- a/docs/02-for-app-authors/03-metainfo-guidelines/01-quality-guidelines.md
+++ b/docs/02-for-app-authors/03-metainfo-guidelines/01-quality-guidelines.md
@@ -251,7 +251,7 @@ Do not use screenshots taken on other platforms, especially if it's immediately 
 
 ### Default settings
 
-Use the platform default configuration for all settings that affect screenshots, including window controls, interface font, large text, high contrast, dark style, and so on. Having some screenshots to show off that e.g. dark style is supported is fine, but these should not be the only screenshots.
+Use the platform default configuration for all settings that affect screenshots, including window controls, interface font, large text, high contrast, dark style, accent color, and so on. Having some screenshots to show off that e.g. dark style is supported is fine, but these should not be the only screenshots.
 
 ![Examples of screenshots with default settings and custom font, window button layout, and high contrast enabled.](assets/screenshot-default.png)
 


### PR DESCRIPTION
I think it would be nice to require default accent colors in screenshots now that they're configurable cross-desktop, to keep some degree of consistency across screenshots and make it clear which apps actually have an overriden accent color. The default is blue for both KDE and GNOME (and elementaryOS if I'm not wrong), so it should be pretty easy to mandate.

/cc @bertob @cassidyjames 