### PR TITLE
Config: add `rel=me` to verify Mastodon account

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -176,6 +176,7 @@ const config = {
               {
                 label: "Mastodon",
                 href: "https://floss.social/@flathub",
+                rel: "noreferrer me",
               },
             ],
           },


### PR DESCRIPTION
Should fix #393 but I wanna make sure that's the right way to edit the config before merging.