### PR TITLE
Split up linter commands

### DIFF
--- a/docs/02-for-app-authors/05-submission.md
+++ b/docs/02-for-app-authors/05-submission.md
@@ -68,6 +68,9 @@ Then build your manifest:
 
    ```bash
    flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest <manifest>
+   ```
+
+   ```bash
    flatpak run --command=flatpak-builder-lint org.flatpak.Builder repo repo
    ```
 


### PR DESCRIPTION
This might be nicer, as you probably want to run each of these isolated and need to replace the `<manifest>` part anyway. So doing it like this, makes the copy button nicer.

@bbhtt 