### PR TITLE
Safety post: iterate to recondense/improve flow

### DIFF
--- a/blog/2025-02-21/index.md
+++ b/blog/2025-02-21/index.md
@@ -29,7 +29,7 @@ Flatpak apps are also built from a declarative manifest, which defines the exact
 
 Due to Flatpak’s sandboxing, apps don’t have permission to access many aspects of the host OS or user data they might need. To get that access, apps must either request it using Portals or use static permissions.
 
-### Dynamic permissions
+### Portals & Static Permissions
 
 Most permissions can be requested and granted on demand via an API
 called [Portals](https://flatpak.github.io/xdg-desktop-portal/docs/).
@@ -51,31 +51,18 @@ the user’s desktop environment (like GNOME or KDE) manages if and how a
 user is notified or prompted for permissions—and if the permission is
 not granted, the app must handle it gracefully.
 
-Portals is a fairly new addition to the Freedesktop ecosystem; desktop
-environments need to implement them and app developers are increasingly
-adopting them.
+Some permissions are not covered by Portals, such as basic and generally safe
+resources for which dynamic permissions wouldn't make sense. In these cases—or
+if a Portal does not yet exist or is not widely adopted for a certain
+permission—developers may use [static permissions](https://docs.flathub.org/docs/for-app-authors/requirements#permissions). 
+These are set by the developer at build time in the public build manifest.
 
-### Static permissions
-
-Static permissions are set by application developers at build time.
-They allow exposing specific resources from the host into the sandbox
-which makes them accessible as if the sandbox was not there. They serve
-multiple purposes:
-
-1. Give Flatpak apps access to basic and safe resources  for which
-   dynamic permissions would not make sense. For example Wayland or
-   hardware acceleration
-2. Allow apps who haven't implemented portals to be functional
-3. Provide a solution when a portal is not available yet for a
-   specific feature
-
-See also
-
-* [Sandbox Permissions on flatpak.org](https://docs.flatpak.org/en/latest/sandbox-permissions.html)
-* [Permissions on flathub.org](https://docs.flathub.org/docs/for-app-authors/requirements#permissions)
-
-Static permissions are reviewed by Flathub human reviewers when a new
-application is submitted and when they are updated between releases.
+Static permissions are intended to be as narrowly-scoped as possible and are
+unchanging for the life of each release of an app. They are not generally
+designed to be modified by an end user except in cases of development,
+debugging, or [reducing permissions](https://docs.flathub.org/docs/for-users/permissions).
+Due to this, Flatpak always prefers apps to use Portals over static permissions
+whenever possible.
 
 ### Shared Runtimes & Modules
 
@@ -83,9 +70,7 @@ Every app is built against a [Flatpak runtime](https://docs.flatpak.org/en/lates
 
 Runtimes are automatically installed with apps that require them, and are updated separately by the user’s OS, app store, or CLI when needed. When a dependency in a runtime is updated, e.g. for a critical security update, it rolls out as an update to all users of apps that use that runtime.
 
-In some cases there are commonly-used libraries not provided directly by one of the available runtimes. Flathub provides [shared modules](https://docs.flathub.org/docs/for-app-authors/shared-modules) for these libraries to centralize the maintenance.
-
-If an app needs to bundle other dependencies, they must be defined in the manifest. We also provide [tooling to automatically suggest updates](https://github.com/flathub-infra/flatpak-external-data-checker) to these dependencies.
+In some cases there are commonly-used libraries not provided directly by one of the available runtimes. Flathub provides [shared modules](https://docs.flathub.org/docs/for-app-authors/shared-modules) for these libraries to centralize the maintenance. If an app needs to bundle other dependencies, they must be defined in the manifest. We also provide [tooling to automatically suggest updates](https://github.com/flathub-infra/flatpak-external-data-checker) to app dependencies.
 
 ## Submission & Human Review
 
@@ -134,8 +119,8 @@ Flathub.org and GNOME Software also display the app’s verified status.
 
 ## Updates
 
-Once an app is accepted onto Flathub, it still remains subject to
-various built-in protections to ensure security.
+Once an app is accepted onto Flathub, it still remains subject to number of 
+safety protections built into the flow:
 
 - **Flathub maintains ownership over the manifest repo**, while app developers are invited as limited collaborators
 - **The manifest repo’s default branch is protected**, preventing direct pushes without a pull request
@@ -155,11 +140,10 @@ Flathub has granted a select group of trusted partners, including Mozilla and OB
 
 Lastly, some apps (around 6%) use [extra-data](https://docs.flatpak.org/en/latest/module-sources.html#extra-data) to instruct Flatpak to download and unpack an existing package (e.g. a Debian package) during installation. This process runs in a tight unprivileged Flatpak sandbox that does not allow host filesystem or network access, and the sandbox cannot be modified by app developers. These are largely proprietary apps that cannot be built on Flathub’s infrastructure, or apps using complex toolchains that require network access during build. This is discouraged since it does not enable the same level of auditability nor multi-architecture support that building from source does. As a result, this is heavily scrutinized during human review and only accepted as a last resort.
 
-Even with the above, the vast majority of apps are built reproducibly
-from source on Flathub’s infrastructure and 83% of the app catalog
-supports multiple architectures. The handful of apps that aren’t built
-from source still greatly benefit from the transparency and auditability
-built into all of the other layers.
+Even with the above, the vast majority of apps are built reproducibly from
+source on Flathub’s infrastructure. The handful of apps that aren’t still
+greatly benefit from the transparency and auditability built into all of the
+other layers.
 
 ## Incident Response
 

--- a/blog/2025-02-21/index.md
+++ b/blog/2025-02-21/index.md
@@ -52,7 +52,7 @@ user is notified or prompted for permissions—and if the permission is
 not granted, the app must handle it gracefully.
 
 Some permissions are not covered by Portals, such as basic and generally safe
-resources for which dynamic permissions wouldn't make sense. In these cases—or
+resources for which dynamic permissions wouldn’t make sense. In these cases—or
 if a Portal does not yet exist or is not widely adopted for a certain
 permission—developers may use [static permissions](https://docs.flathub.org/docs/for-app-authors/requirements#permissions). 
 These are set by the developer at build time in the public build manifest.
@@ -83,7 +83,7 @@ Once an app is developed, it must be submitted to Flathub for consideration to b
 
 - **App IDs must accurately reflect the developer’s domain name** or code hosting location; e.g. if an app is submitted that purports to be Lutris, its ID must be obviously associated with that app (in this case, [Lutris.net](https://lutris.net)).
 
-Each of the documented requirements are checked—and if a reviewer finds something out of place they request changes to the submission, ask for rationale, or reject it completely.
+The app’s Flatpak manifest is reviewed, including all static permissions. Each of the documented requirements are checked—and if a reviewer finds something out of place they request changes to the submission, ask for rationale, or reject it completely.
 
 ## Automated Testing
 
@@ -95,7 +95,7 @@ Once an app has been approved and passes initial tests, it is built using the op
 
 For further auditability, we specify the git commit of the manifest repo used for the build in the Flatpak build subject. The build itself is signed by Flathub’s key, and Flatpak/OSTree verify these signatures when installing and updating apps.
 
-We mirror the exact sources each app is built against in case the original source goes down or there is some other issue, and anyone can build the Flatpak back from those mirrored sources to reproduce or audit the build. The manifest used to build the app is hosted on Flathub's GitHub org, plus distributed to every user in the app’s sandbox at `/app/manifest.json`—both of which can be compared, inspected, and used to rebuild the app exactly as it was built by Flathub.
+We mirror the exact sources each app is built against in case the original source goes down or there is some other issue, and anyone can build the Flatpak back from those mirrored sources to reproduce or audit the build. The manifest used to build the app is hosted on Flathub’s GitHub org, plus distributed to every user in the app’s sandbox at `/app/manifest.json`—both of which can be compared, inspected, and used to rebuild the app exactly as it was built by Flathub.
 
 ## Verification
 


### PR DESCRIPTION
I had feedback on some of the changes suggested to my post, but didn't get a chance to review it before I went to bed. In general I was happy with the sentiment—thanks @sonnyp. I did revert and recondense a little bit of it for flow and to keep the focus largely on safety and the journey from start to finish (e.g. without mentioning human review until the human review section).

Hard wrapping drives me a bit nuts for long-form content because it causes reformatting of many lines when even small amounts of copy change, but I've left it in the sections that were touched. In general, soft wrapping plus the inline diff on GitHub does a good job of highlighting changes without causing more noise and reflowing.

Thanks again everyone for the reviews and improvements!