### PR TITLE
Quality Guidelines: be a bit more lenient with complex screenshots

### DIFF
--- a/docs/02-for-app-authors/03-metainfo-guidelines/01-quality-guidelines.md
+++ b/docs/02-for-app-authors/03-metainfo-guidelines/01-quality-guidelines.md
@@ -387,6 +387,11 @@ smaller (2000x1400 for HiDPI).
 
 ![Examples for screenshots that are too large, and the correct size.](assets/screenshot-size.png)
 
+For complex apps that are often used maximized and with many UI panels 
+(e.g. 3D modeling or game engines), larger screenshots may be used so 
+long as they are visually helpful, the specific UI text is less 
+important, and the screenshot is demonstrative of typical use of the app.
+
 ### Image captions
 
 Every screenshot should have a [caption](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-screenshots)


### PR DESCRIPTION
Things like Blender or Godot Engine are _never used_ at tiny sizes, and requiring smaller screenshots just punishes them for being large, complex, professional apps.

Instead, we should recognize that those are a different sort of class of app and that it's more useful to show how they're actually used than some fictional world where you're advertising how Blender looks on an 10" tablet.

This is based on feedback we've received in the ["App developer feedback about quality guidelines" thread](https://discourse.flathub.org/t/app-developer-feedback-about-quality-guidelines/8037/) as well more broadly (I forget if it was social media, specific apps, or just talking to the Godot folks…).