### PR TITLE
Allow JPEG and WebP images as Screenshot in the Banner Preview

### DIFF
--- a/src/pages/banner-preview.tsx
+++ b/src/pages/banner-preview.tsx
@@ -144,7 +144,7 @@ function BannerPreviewPage() {
                   type="file"
                   id="screenshot"
                   name="screenshot"
-                  accept="image/png"
+                  accept="image/png, image/jpeg, image/webp"
                   onChange={(e) => handleScreenshotChange(e)}
                 />
               </div>


### PR DESCRIPTION
From https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-screenshots

> Images should ideally be provided in the PNG format; using JPEG or WebP is also permitted for images in metainfo files. 