### PR TITLE
Clarify that new linter folder errors also include subfolders

### DIFF
--- a/docs/02-for-app-authors/12-linter.md
+++ b/docs/02-for-app-authors/12-linter.md
@@ -620,22 +620,22 @@ can also be used for this.
 ### finish-args-full-home-config-access
 
 The [finish-args](https://docs.flatpak.org/en/latest/manifests.html#finishing)
-in the manifest has filesystem access to entire `~/.config`.
+in the manifest has filesystem access to entire `~/.config` or its subdirectories.
 
 ### finish-args-full-home-cache-access
 
 The [finish-args](https://docs.flatpak.org/en/latest/manifests.html#finishing)
-in the manifest has filesystem access to entire `~/.cache`.
+in the manifest has filesystem access to entire `~/.cache` or its subdirectories.
 
 ### finish-args-full-home-local-access
 
 The [finish-args](https://docs.flatpak.org/en/latest/manifests.html#finishing)
-in the manifest has filesystem access to entire `~/.local`.
+in the manifest has filesystem access to entire `~/.local` or its subdirectories.
 
 ### finish-args-full-home-local-share-access
 
 The [finish-args](https://docs.flatpak.org/en/latest/manifests.html#finishing)
-in the manifest has filesystem access to entire `~/.local/share`.
+in the manifest has filesystem access to entire `~/.local/share` or its subdirectories.
 
 ### finish-args-absolute-home-path
 


### PR DESCRIPTION
This had me through a loop because it sounded like only the main directories, not also the subdirectories, were disallowed without exceptions, thus this adds acknowledgement of subfolders also counting.

It might be worth also recommending usage of `xdg-data` instead of `.local/share`, but I'm not sure how best to word that if so given the need for an exception for `xdg-data/...` too.