### PR TITLE
metainfo: use supports instead of recommends for proper appstream compatibiltiy

### DIFF
--- a/docs/02-for-app-authors/03-metainfo-guidelines/index.md
+++ b/docs/02-for-app-authors/03-metainfo-guidelines/index.md
@@ -606,11 +606,11 @@ touch (mobile and tablet) devices.
 
 ```xml
 <!-- Desktop AND mobile supported -->
-<recommends>
+<supports>
   <control>keyboard</control>
   <control>pointing</control>
   <control>touch</control>
-</recommends>
+</supports>
 ```
 
 The below metadata will indicate that the app supports only desktop
@@ -648,11 +648,11 @@ but if it supports gamepad along with other inputs like keyboard and
 mouse, it should instead use
 
 ```xml
-<recommends>
+<supports>
   <control>keyboard</control>
   <control>pointing</control>
   <control>gamepad</control>
-</recommends>
+</supports>
 ```
 
 ### Display size
@@ -734,11 +734,11 @@ should have:
 
 
 ```xml
-<recommends>
+<supports>
   <control>keyboard</control>
   <control>pointing</control>
   <control>touch</control>
-</recommends>
+</supports>
 <requires>
   <display_length compare="ge">360</display_length>
 </requires>


### PR DESCRIPTION
appstreamcli doesn't report mobile as 100% compatible if `recommends` is used for keyboard and pointer. If an app is designed for desktop and mobile then `supports` should probably be used.

<hr />
If a metainfo has this:

```xml
<recommends>
	<control>keyboard</control>
	<control>pointing</control>
	<control>touch</control>
</recommends>
<requires>
	<display_length compare="ge">360</display_length>
</requires>
```

then `appstreamcli check-syscompat` will report it as:

```bash
Desktop:
 ✔ Compatible (100%)

Laptop:
 ✔ Compatible (100%)

Server:
 ✘ Incompatible

Tablet:
 ✔ Compatible (85%)

Handset:
 ✔ Compatible (85%)
```
This only has 85% compatibility for handset and tablet.


<hr />

If `supports` is used instead of `recommends` then `appstreamcli check-syscompat` will report it as:

```bash
Desktop:
 ✔ Compatible (100%)

Laptop:
 ✔ Compatible (100%)

Server:
 ✘ Incompatible

Tablet:
 ✔ Compatible (100%)

Handset:
 ✔ Compatible (100%)
```
