### PR TITLE
Fix typo: artificats to artifacts

### DIFF
--- a/docs/02-for-app-authors/02-requirements.md
+++ b/docs/02-for-app-authors/02-requirements.md
@@ -504,7 +504,7 @@ New submissions will not be accepted for the Flathub beta repostitory.
 ## Required files
 
 :::important
-Under no circumstances should source code nor build artificats be
+Under no circumstances should source code nor build artifacts be
 included in the submission. Flathub is not intended to host neither
 application source code nor binaries, including that of any dependencies.
 :::


### PR DESCRIPTION
Fixed typo in "Under no circumstances should source code nor build artificats be included in the submission. Flathub is not intended to host neither application source code nor binaries, including that of any dependencies."